### PR TITLE
Fix for players waiting to be deleted

### DIFF
--- a/src/player.php
+++ b/src/player.php
@@ -45,6 +45,11 @@ class Player
                 }
             }
 
+            if (isset($this->player['name'])) {
+                $explode = explode(', will ', $this->player['name']);
+                $this->player['name'] = $explode[0];
+            }
+            
             if (isset($this->player["house"])) {
                 $explode = explode(" is paid until ", $this->player["house"]);
                 $house_explode = explode(" (", $explode[0]);


### PR DESCRIPTION
When crawling a player waiting to be deleted the name will return ', will be deleted At {time}' appended to the player name.