### PR TITLE
Fix on former_names property

### DIFF
--- a/src/player.php
+++ b/src/player.php
@@ -45,6 +45,11 @@ class Player
                 }
             }
 
+            if (isset($this->player['name'])) {
+                $explode = explode(', will ', $this->player['name']);
+                $this->player['name'] = $explode[0];
+            }
+            
             if (isset($this->player["house"])) {
                 $explode = explode(" is paid until ", $this->player["house"]);
                 $house_explode = explode(" (", $explode[0]);

--- a/src/player.php
+++ b/src/player.php
@@ -45,9 +45,14 @@ class Player
                 }
             }
 
-            if (isset($this->player['name'])) {
-                $explode = explode(', will ', $this->player['name']);
-                $this->player['name'] = $explode[0];
+            if (isset($this->player["name"])) {
+                $explode = explode(", will ", $this->player["name"]);
+                $this->player["name"] = $explode[0];
+            }
+            
+            if (isset($this->player["former_names"])) {
+                $explode = explode(",", $this->player["former_names"]);
+                $this->player["former_names"] = array_map("trim", $explode);
             }
             
             if (isset($this->player["house"])) {


### PR DESCRIPTION
This pull request changes the `former_names` property to an array since a player can have more than one former name.

Also changed single quotes to double quotes on previous commit.